### PR TITLE
Bugfix to avoid memory leak

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# 1.3.3 #  
+    
+Bufgix to avoid memory leak.</br>  
+  
 # 1.3.2 #  
     
 Reading of negative numbers and error handling improved, in Modbus and Snap7.</br>  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="https://github.com/homebridge/branding/raw/master/logos/homebridge-wordmark-logo-vertical.png" width="150">
+  <img src="https://raw.githubusercontent.com/homebridge/branding/master/logos/homebridge-color-round-stylized.png" height="140"></a>
 </p>
 
 # Homebridge Logo Platform #
@@ -71,6 +71,7 @@ Name                     | Value               | Required     | Notes
 `localTSAP`              | "0x1200"            | no (Snap7)   | Must be set to the local TSAP of your LOGO!, default is: "0x1200".
 `remoteTSAP`             | "0x2200"            | no (Snap7)   | Must be set to the remote TSAP of your LOGO!, default is: "0x2200".
 `queueInterval`          | 100 ... 1000        | no           | Interval to send queries from Plugin to LOGO!, in milliseconds, default is: 100.
+`queueSize`              | 100 ... 1000        | no           | Number of items to be hold in send/receive queue, default is: 100.
 `updateInterval`         | 0 ... ∞             | no           | Auto Update Interval in milliseconds, 0 = Off
 `debugMsgLog`            | 0 or 1              | no           | Displays messages of all accessories in the log, default is: 0.
 `retryCount`             | 0 ... ∞             | no           | Retry count for sending the queries messages, default is: 5.

--- a/config.schema.json
+++ b/config.schema.json
@@ -61,6 +61,11 @@
         "type": "number",
         "placeholder": "100"
       },
+      "queueSize": {
+        "title": "Number of items to be hold in send/receive queue, default is: 100.",
+        "type": "number",
+        "placeholder": "100"
+      },
       "updateInterval": {
         "title": "Auto Update Interval in milliseconds, 0 = Off",
         "type": "number",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Logo Platform",
   "name": "homebridge-logo-platform",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "model": "Logo Platform",
   "description": "This is a Siemens LOGO! Platform Plugin.",
   "license": "---",
@@ -42,14 +42,14 @@
     "node-snap7": "^1.0.6"
   },
   "devDependencies": {
-    "@types/node": "^16.10.9",
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0",
-    "eslint": "^8.0.1",
-    "homebridge": "^1.3.5",
-    "nodemon": "^2.0.13",
+    "@types/node": "^18.16.20",
+    "@typescript-eslint/eslint-plugin": "^5.62.0",
+    "@typescript-eslint/parser": "^5.62.0",
+    "eslint": "^8.45.0",
+    "homebridge": "^1.6.0",
+    "nodemon": "^2.0.22",
     "rimraf": "^3.0.2",
-    "ts-node": "^10.3.0",
-    "typescript": "^4.4.4"
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
   }
 }

--- a/src/accessories/blindPlatformAccessory.ts
+++ b/src/accessories/blindPlatformAccessory.ts
@@ -15,6 +15,11 @@ export class BlindPlatformAccessory implements AccessoryPlugin {
   private platform: any;
   private device: any;
   private pushButton: number;
+  private updateCurrentPositionAndTargetPositionQueued: boolean;
+  private updateCurrentPositionQueued: boolean;
+  private updateTargetPositionQueued: boolean;
+  private updatePositionStateQueued: boolean;
+
 
   private currentPositionIsTargetPositionInLogo: number;
 
@@ -54,6 +59,11 @@ export class BlindPlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.Model,            this.model + ' @ ' + this.platform.model)
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
+
+    this.updateCurrentPositionAndTargetPositionQueued = false;
+    this.updateCurrentPositionQueued = false;
+    this.updateTargetPositionQueued = false;
+    this.updatePositionStateQueued = false;
 
     if (this.platform.config.updateInterval) {
       
@@ -126,6 +136,8 @@ export class BlindPlatformAccessory implements AccessoryPlugin {
   }
 
   updateCurrentPosition() {
+
+    if (this.updateCurrentPositionQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.blindGetPos, async (value: number) => {
 
@@ -140,13 +152,19 @@ export class BlindPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.CurrentPosition, this.accStates.CurrentPosition);
       }
 
+      this.updateCurrentPositionQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentPositionQueued = true;
+    };
 
   }
 
   updatePositionState() {
+
+    if (this.updatePositionStateQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.blindGetState, async (value: number) => {
 
@@ -161,13 +179,19 @@ export class BlindPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.PositionState, this.accStates.PositionState);
       }
 
+      this.updatePositionStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updatePositionStateQueued = true;
+    };
 
   }
 
   updateTargetPosition() {
+
+    if (this.updateTargetPositionQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.blindGetTargetPos, async (value: number) => {
 
@@ -182,13 +206,19 @@ export class BlindPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetPosition, this.accStates.TargetPosition);
       }
 
+      this.updateTargetPositionQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateTargetPositionQueued = true;
+    };
 
   }
 
   updateCurrentPositionAndTargetPosition() {
+
+    if (this.updateCurrentPositionAndTargetPositionQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.blindGetPos, async (value: number) => {
 
@@ -205,9 +235,13 @@ export class BlindPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetPosition, this.accStates.TargetPosition);
       }
 
+      this.updateCurrentPositionAndTargetPositionQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentPositionAndTargetPositionQueued = true;
+    };
 
   }
 

--- a/src/accessories/garagedoorPlatformAccessory.ts
+++ b/src/accessories/garagedoorPlatformAccessory.ts
@@ -15,6 +15,10 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
   private platform: any;
   private device: any;
   private pushButton: number;
+  private updateCurrentDoorStateAndTargetDoorStateQueued: boolean;
+  private updateCurrentDoorStateQueued: boolean;
+  private updateTargetDoorStateQueued: boolean;
+  private updateObstructionDetectedQueued: boolean;
 
   private currentDoorStateIsTargetDoorStateInLogo: number;
 
@@ -54,6 +58,11 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.Model,            this.model + ' @ ' + this.platform.model)
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
+
+    this.updateCurrentDoorStateAndTargetDoorStateQueued = false;
+    this.updateCurrentDoorStateQueued = false;
+    this.updateTargetDoorStateQueued = false;
+    this.updateObstructionDetectedQueued = false;
 
     if (this.platform.config.updateInterval) {
       
@@ -153,6 +162,8 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
 
     if (this.device.garagedoorObstruction) {
 
+      if (this.updateObstructionDetectedQueued) {return;}
+
       let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.garagedoorObstruction, async (value: number) => {
 
         if (value != ErrorNumber.noData) {
@@ -165,10 +176,14 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
   
           this.service.updateCharacteristic(this.api.hap.Characteristic.ObstructionDetected, this.accStates.ObstructionDetected);
         }
+
+        this.updateObstructionDetectedQueued = false;
   
       });
   
-      this.platform.queue.enqueue(qItem);
+      if (this.platform.queue.enqueue(qItem) === 1) {
+        this.updateObstructionDetectedQueued = true;
+      };
       
     }
     
@@ -176,6 +191,8 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
 
   updateAnalogCurrentDoorState() {
     
+    if (this.updateCurrentDoorStateQueued) {return;}
+
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.garagedoorGetState, async (value: number) => {
 
       if (value != ErrorNumber.noData) {
@@ -189,13 +206,19 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.CurrentDoorState, this.accStates.CurrentDoorState);
       }
 
+      this.updateCurrentDoorStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentDoorStateQueued = true;
+    };
 
   }
 
   updateAnalogTargetDoorState() {
+
+    if (this.updateTargetDoorStateQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.garagedoorGetTargetState, async (value: number) => {
 
@@ -210,13 +233,19 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetDoorState, this.accStates.TargetDoorState);
       }
 
+      this.updateTargetDoorStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateTargetDoorStateQueued = true;
+    };
 
   }
 
   updateAnalogCurrentDoorStateAndTargetDoorState() {
+
+    if (this.updateCurrentDoorStateAndTargetDoorStateQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.garagedoorGetState, async (value: number) => {
 
@@ -233,13 +262,19 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetDoorState, this.accStates.TargetDoorState);
       }
 
+      this.updateCurrentDoorStateAndTargetDoorStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentDoorStateAndTargetDoorStateQueued = true;
+    };
 
   }
 
   updateDigitalCurrentDoorState() {
+
+    if (this.updateCurrentDoorStateQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.garagedoorGetState, async (value: number) => {
       // Logo return 1 for open !!
@@ -254,13 +289,19 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.CurrentDoorState, this.accStates.CurrentDoorState);
       }
 
+      this.updateCurrentDoorStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentDoorStateQueued = true;
+    };
 
   }
 
   updateDigitalTargetDoorState() {
+
+    if (this.updateTargetDoorStateQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.garagedoorGetTargetState, async (value: number) => {
       // Logo return 1 for open !!
@@ -275,13 +316,19 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetDoorState, this.accStates.TargetDoorState);
       }
 
+      this.updateTargetDoorStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateTargetDoorStateQueued = true;
+    };
 
   }
 
   updateDigitalCurrentDoorStateAndTargetDoorState() {
+
+    if (this.updateCurrentDoorStateAndTargetDoorStateQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.garagedoorGetState, async (value: number) => {
       // Logo return 1 for open !!
@@ -298,9 +345,13 @@ export class GaragedoorPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetDoorState, this.accStates.TargetDoorState);
       }
 
+      this.updateCurrentDoorStateAndTargetDoorStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentDoorStateAndTargetDoorStateQueued = true;
+    };
 
   }
 

--- a/src/accessories/irrigationSystemPlatformAccessory.ts
+++ b/src/accessories/irrigationSystemPlatformAccessory.ts
@@ -15,6 +15,9 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
   private platform: any;
   private device: any;
   private pushButton: number;
+  private updateActiveQueued: boolean;
+  private updateProgramModeQueued: boolean;
+  private updateInUseQueued: boolean;
 
   private accStates = {
     Active: 0,
@@ -51,6 +54,10 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.Model,            this.model + ' @ ' + this.platform.model)
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
+
+    this.updateActiveQueued = false;
+    this.updateProgramModeQueued = false;
+    this.updateInUseQueued = false;
 
     if (this.platform.config.updateInterval) {
       
@@ -118,6 +125,8 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
   }
 
   updateActive() {
+
+    if (this.updateActiveQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.irrigationSystemGetActive, async (value: number) => {
 
@@ -132,13 +141,19 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.Active, this.accStates.Active);
       }
 
+      this.updateActiveQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateActiveQueued = true;
+    };
 
   }
 
   updateProgramMode() {
+
+    if (this.updateProgramModeQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.irrigationSystemGetProgramMode, async (value: number) => {
 
@@ -153,13 +168,19 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.ProgramMode, this.accStates.ProgramMode);
       }
 
+      this.updateProgramModeQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateProgramModeQueued = true;
+    };
 
   }
 
   updateInUse() {
+
+    if (this.updateInUseQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.irrigationSystemGetInUse, async (value: number) => {
 
@@ -174,9 +195,13 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.InUse, this.accStates.InUse);
       }
 
+      this.updateInUseQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateInUseQueued = true;
+    };
 
   }
 

--- a/src/accessories/thermostatPlatformAccessory.ts
+++ b/src/accessories/thermostatPlatformAccessory.ts
@@ -15,6 +15,10 @@ export class ThermostatPlatformAccessory implements AccessoryPlugin {
   private platform: any;
   private device: any;
   private pushButton: number;
+  private updateCurrentHeatingCoolingStateQueued: boolean;
+  private updateTargetHeatingCoolingStateQueued: boolean;
+  private updateCurrentTemperatureQueued: boolean;
+  private updateTargetTemperatureQueued: boolean;
 
   private accStates = {
     CurrentHeatingCoolingState: 0,
@@ -62,6 +66,11 @@ export class ThermostatPlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.Model,            this.model + ' @ ' + this.platform.model)
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
+
+      this.updateCurrentHeatingCoolingStateQueued = false;
+      this.updateTargetHeatingCoolingStateQueued = false;
+      this.updateCurrentTemperatureQueued = false;
+      this.updateTargetTemperatureQueued = false;
 
     if (this.platform.config.updateInterval) {
       
@@ -160,6 +169,8 @@ export class ThermostatPlatformAccessory implements AccessoryPlugin {
   }
 
   updateCurrentHeatingCoolingState() {
+
+    if (this.updateCurrentHeatingCoolingStateQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.thermostatGetHCState, async (value: number) => {
 
@@ -174,13 +185,19 @@ export class ThermostatPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.CurrentHeatingCoolingState, this.accStates.CurrentHeatingCoolingState);
       }
 
+      this.updateCurrentHeatingCoolingStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentHeatingCoolingStateQueued = true;
+    };
 
   }
 
   updateTargetHeatingCoolingState() {
+
+    if (this.updateTargetHeatingCoolingStateQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.thermostatGetTargetHCState, async (value: number) => {
 
@@ -195,13 +212,19 @@ export class ThermostatPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetHeatingCoolingState, this.accStates.TargetHeatingCoolingState);
       }
 
+      this.updateTargetHeatingCoolingStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateTargetHeatingCoolingStateQueued = true;
+    };
 
   }
 
   updateCurrentTemperature() {
+
+    if (this.updateCurrentTemperatureQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.thermostatGetTemp, async (value: number) => {
 
@@ -226,13 +249,19 @@ export class ThermostatPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.CurrentTemperature, this.accStates.CurrentTemperature);
       }
 
+      this.updateCurrentTemperatureQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentTemperatureQueued = true;
+    };
 
   }
 
   updateTargetTemperature() {
+
+    if (this.updateTargetTemperatureQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.thermostatGetTargetTemp, async (value: number) => {
 
@@ -258,9 +287,13 @@ export class ThermostatPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetTemperature, this.accStates.TargetTemperature);
       }
 
+      this.updateTargetTemperatureQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateTargetTemperatureQueued = true;
+    };
 
   }
 

--- a/src/accessories/valvePlatformAccessory.ts
+++ b/src/accessories/valvePlatformAccessory.ts
@@ -15,6 +15,10 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
   private platform: any;
   private device: any;
   private pushButton: number;
+  private updateActiveQueued: boolean;
+  private updateInUseQueued: boolean;
+  private updateRemainingDurationQueued: boolean;
+  private updateSetDurationQueued: boolean;
 
   private accStates = {
     Active: 0,
@@ -67,15 +71,20 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
 
+    this.updateActiveQueued = false;
+    this.updateInUseQueued = false;
+    this.updateRemainingDurationQueued = false;
+    this.updateSetDurationQueued = false;
+
     if (this.platform.config.updateInterval) {
-      
+
       setInterval(() => {
         this.updateActive();
         this.updateInUse();
         this.updateRemainingDuration();
         this.updateSetDuration();
       }, this.platform.config.updateInterval);
-
+      
     }
     
   }
@@ -166,6 +175,8 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
 
   updateActive() {
     
+    if (this.updateActiveQueued) {return;}
+
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.valveGetActive, async (value: number) => {
 
       if (value != ErrorNumber.noData) {
@@ -177,16 +188,23 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
         }
 
         this.service.updateCharacteristic(this.api.hap.Characteristic.Active, this.accStates.Active);
+
       }
+
+      this.updateActiveQueued = false;
 
     });
 
-    this.platform.queue.enqueue(qItem);
+    if(this.platform.queue.enqueue(qItem) === 1) {
+      this.updateActiveQueued = true;
+    }
   
   }
 
   updateInUse() {
     
+    if (this.updateInUseQueued){return;}
+
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.valveGetInUse, async (value: number) => {
 
       if (value != ErrorNumber.noData) {
@@ -198,11 +216,16 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
         }
 
         this.service.updateCharacteristic(this.api.hap.Characteristic.InUse, this.accStates.InUse);
+
       }
+
+      this.updateInUseQueued = false;
 
     });
 
-    this.platform.queue.enqueue(qItem);
+    if(this.platform.queue.enqueue(qItem) === 1) {
+      this.updateInUseQueued = true;
+    }
 
   }
 
@@ -210,22 +233,29 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
 
     if (this.device.valveGetRemainingDuration) {
 
+      if (this.updateRemainingDurationQueued){return;}
+      
       let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.valveGetRemainingDuration, async (value: number) => {
 
         if (value != ErrorNumber.noData) {
-  
+
           this.accStates.RemainingDuration = value as number;
-  
+
           if (this.platform.config.debugMsgLog || this.device.debugMsgLog) {
             this.platform.log.info('[%s] Get RemainingDuration -> %i', this.device.name, this.accStates.RemainingDuration);
           }
-  
+
           this.service.updateCharacteristic(this.api.hap.Characteristic.RemainingDuration, this.accStates.RemainingDuration);
+
         }
-  
+
+        this.updateRemainingDurationQueued = false;
+
       });
-  
-      this.platform.queue.enqueue(qItem);
+
+      if(this.platform.queue.enqueue(qItem) === 1) {
+        this.updateRemainingDurationQueued = true;
+      }
       
     }
 
@@ -235,22 +265,28 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
     
     if (this.device.valveGetDuration) {
       
+      if (this.updateSetDurationQueued) {return;}
+      
       let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.valveGetDuration, async (value: number) => {
 
         if (value != ErrorNumber.noData) {
-  
+
           this.accStates.SetDuration = value as number;
-  
+
           if (this.platform.config.debugMsgLog || this.device.debugMsgLog) {
             this.platform.log.info('[%s] Get SetDuration -> %i', this.device.name, this.accStates.SetDuration);
           }
-  
+
           this.service.updateCharacteristic(this.api.hap.Characteristic.SetDuration, this.accStates.SetDuration);
         }
-  
+
+        this.updateSetDurationQueued = false;
+
       });
-  
-      this.platform.queue.enqueue(qItem);
+
+      if(this.platform.queue.enqueue(qItem) === 1) {
+        this.updateSetDurationQueued = true;
+      }
 
     }
 

--- a/src/accessories/windowPlatformAccessory.ts
+++ b/src/accessories/windowPlatformAccessory.ts
@@ -15,6 +15,10 @@ export class WindowPlatformAccessory implements AccessoryPlugin {
   private platform: any;
   private device: any;
   private pushButton: number;
+  private updateCurrentPositionAndTargetPositionQueued: boolean;
+  private updateCurrentPositionQueued: boolean;
+  private updateTargetPositionQueued: boolean;
+  private updatePositionStateQueued: boolean;
 
   private currentPositionIsTargetPositionInLogo: number;
 
@@ -55,6 +59,11 @@ export class WindowPlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
 
+    this.updateCurrentPositionAndTargetPositionQueued = false;
+    this.updateCurrentPositionQueued = false;
+    this.updateTargetPositionQueued = false;
+    this.updatePositionStateQueued = false;
+    
     if (this.platform.config.updateInterval) {
       
       setInterval(() => {
@@ -126,6 +135,8 @@ export class WindowPlatformAccessory implements AccessoryPlugin {
   }
 
   updateCurrentPosition() {
+
+    if (this.updateCurrentPositionQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.windowGetPos, async (value: number) => {
 
@@ -140,13 +151,19 @@ export class WindowPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.CurrentPosition, this.accStates.CurrentPosition);
       }
 
+      this.updateCurrentPositionQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentPositionQueued = true;
+    };
 
   }
 
   updatePositionState() {
+
+    if (this.updatePositionStateQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.windowGetState, async (value: number) => {
 
@@ -161,13 +178,19 @@ export class WindowPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.PositionState, this.accStates.PositionState);
       }
 
+      this.updatePositionStateQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updatePositionStateQueued = true;
+    };
 
   }
 
   updateTargetPosition() {
+
+    if (this.updateTargetPositionQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.windowGetTargetPos, async (value: number) => {
 
@@ -182,13 +205,19 @@ export class WindowPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetPosition, this.accStates.TargetPosition);
       }
 
+      this.updateTargetPositionQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateTargetPositionQueued = true;
+    };
 
   }
 
   updateCurrentPositionAndTargetPosition() {
+
+    if (this.updateCurrentPositionAndTargetPositionQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.windowGetPos, async (value: number) => {
 
@@ -205,9 +234,13 @@ export class WindowPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.TargetPosition, this.accStates.TargetPosition);
       }
 
+      this.updateCurrentPositionAndTargetPositionQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCurrentPositionAndTargetPositionQueued = true;
+    };
 
   }
 

--- a/src/modbus-logo.ts
+++ b/src/modbus-logo.ts
@@ -94,7 +94,7 @@ export class ModBusLogo {
 
             if (addr.type == AddressType.MBATCoil) {
 
-                this.wiriteCoil(addr.addr, (value == 1 ? true : false), this.debugMsgLog, this.log, this.retryCnt); 
+                this.writeCoil(addr.addr, (value == 1 ? true : false), this.debugMsgLog, this.log, this.retryCnt); 
 
             }
 
@@ -288,11 +288,11 @@ export class ModBusLogo {
         });
     }
 
-    wiriteCoil(addr: number, state: Boolean, debugLog: number, log: any, retryCount: number) {
+    writeCoil(addr: number, state: Boolean, debugLog: number, log: any, retryCount: number) {
         
         if (retryCount == 0) {
             if (debugLog == 1) {
-                log('wiriteCoil() - Retry counter reached max value');
+                log('writeCoil() - Retry counter reached max value');
             }
             return ErrorNumber.noData;
         }
@@ -311,7 +311,7 @@ export class ModBusLogo {
                     }
 
                     sleep(100).then(() => {
-                        this.wiriteCoil(addr, state, debugLog, log, retryCount); 
+                        this.writeCoil(addr, state, debugLog, log, retryCount); 
                     });
 
                 }

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -22,8 +22,10 @@ export class QueueReceiveItem {
 
 export class Queue {
     items: any[];
+    capacity: number;
 
-    constructor(...params: any[]) {
+    constructor(capacity: number, ...params: any[]) {
+        this.capacity = capacity;
         this.items = [...params];
     }
 
@@ -32,7 +34,11 @@ export class Queue {
     }
 
     enqueue(item: any) {
-        this.items.push(item);
+        if (this.items.length < this.capacity) {
+            this.items.push(item);
+            return 1;
+        }
+        return 0;
     }
 
     dequeue() {

--- a/src/sensors/carbonDioxideSensorPlatformAccessory.ts
+++ b/src/sensors/carbonDioxideSensorPlatformAccessory.ts
@@ -14,6 +14,9 @@ export class CarbonDioxideSensorPlatformAccessory implements AccessoryPlugin {
 
   private platform: any;
   private device: any;
+  private updateCarbonDioxideDetectedQueued: boolean;
+  private updateCarbonDioxideLevelQueued: boolean;
+  private updateCarbonDioxidePeakLevelQueued: boolean;
 
   private sensStates = {
     CarbonDioxideDetected: 0,
@@ -53,7 +56,11 @@ export class CarbonDioxideSensorPlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
 
-    if (this.platform.config.updateInterval) {
+    this.updateCarbonDioxideDetectedQueued = false;
+    this.updateCarbonDioxideLevelQueued = false;
+    this.updateCarbonDioxidePeakLevelQueued = false;
+    
+      if (this.platform.config.updateInterval) {
       
       setInterval(() => {
         this.updateCarbonDioxideDetected();
@@ -100,6 +107,8 @@ export class CarbonDioxideSensorPlatformAccessory implements AccessoryPlugin {
   }
 
   updateCarbonDioxideDetected() {
+
+    if (this.updateCarbonDioxideDetectedQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.carbonDioxide, async (value: number) => {
 
@@ -114,15 +123,21 @@ export class CarbonDioxideSensorPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.CarbonDioxideDetected, this.sensStates.CarbonDioxideDetected);
       }
 
+      this.updateCarbonDioxideDetectedQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateCarbonDioxideDetectedQueued = true;
+    };
 
   }
 
   updateCarbonDioxideLevel() {
 
     if (this.device.carbonDioxideLevel) {
+
+      if (this.updateCarbonDioxideLevelQueued) {return;}
       
       let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.carbonDioxideLevel, async (value: number) => {
 
@@ -136,10 +151,14 @@ export class CarbonDioxideSensorPlatformAccessory implements AccessoryPlugin {
   
           this.service.updateCharacteristic(this.api.hap.Characteristic.CarbonDioxideLevel, this.sensStates.CarbonDioxideLevel);
         }
+
+        this.updateCarbonDioxideLevelQueued = false;
   
       });
   
-      this.platform.queue.enqueue(qItem);
+      if (this.platform.queue.enqueue(qItem) === 1) {
+        this.updateCarbonDioxideLevelQueued = true;
+      };
 
     }
 
@@ -148,6 +167,8 @@ export class CarbonDioxideSensorPlatformAccessory implements AccessoryPlugin {
   updateCarbonDioxidePeakLevel() {
 
     if (this.device.carbonDioxidePeakLevel) {
+
+      if (this.updateCarbonDioxidePeakLevelQueued) {return;}
       
       let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.carbonDioxidePeakLevel, async (value: number) => {
 
@@ -161,10 +182,14 @@ export class CarbonDioxideSensorPlatformAccessory implements AccessoryPlugin {
   
           this.service.updateCharacteristic(this.api.hap.Characteristic.CarbonDioxidePeakLevel, this.sensStates.CarbonDioxidePeakLevel);
         }
+
+        this.updateCarbonDioxidePeakLevelQueued = false;
   
       });
   
-      this.platform.queue.enqueue(qItem);
+      if (this.platform.queue.enqueue(qItem) === 1) {
+        this.updateCarbonDioxidePeakLevelQueued = true;
+      };
 
     }
 

--- a/src/sensors/motionSensorPlatformAccessory.ts
+++ b/src/sensors/motionSensorPlatformAccessory.ts
@@ -74,7 +74,7 @@ export class MotionSensorPlatformAccessory implements AccessoryPlugin {
 
   updateMotionDetected() {
     
-    if (this.updateOnQueued) {return;}
+    if (this.updateMotionDetectedQueued) {return;}
     
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.motion, async (value: number) => {
 

--- a/src/sensors/motionSensorPlatformAccessory.ts
+++ b/src/sensors/motionSensorPlatformAccessory.ts
@@ -14,6 +14,7 @@ export class MotionSensorPlatformAccessory implements AccessoryPlugin {
 
   private platform: any;
   private device: any;
+  private updateMotionDetectedQueued: boolean;
 
   private sensStates = {
     MotionDetected: false,
@@ -40,6 +41,8 @@ export class MotionSensorPlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.Model,            this.model + ' @ ' + this.platform.model)
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
+
+    this.updateMotionDetectedQueued = false;
 
     if (this.platform.config.updateInterval) {
       
@@ -71,6 +74,8 @@ export class MotionSensorPlatformAccessory implements AccessoryPlugin {
 
   updateMotionDetected() {
     
+    if (this.updateOnQueued) {return;}
+    
     let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.motion, async (value: number) => {
 
       if (value != ErrorNumber.noData) {
@@ -84,9 +89,13 @@ export class MotionSensorPlatformAccessory implements AccessoryPlugin {
         this.service.updateCharacteristic(this.api.hap.Characteristic.MotionDetected, this.sensStates.MotionDetected);
       }
 
+      this.updateMotionDetectedQueued = false;
+
     });
 
-    this.platform.queue.enqueue(qItem);
+    if (this.platform.queue.enqueue(qItem) === 1) {
+      this.updateMotionDetectedQueued = true;
+    };
 
   }
 


### PR DESCRIPTION
**Bugfix to avoid memory leak when update interval is set. Closes #8**

**Changes:**
- Added _queueSize_ parameter to limit overall queue size
- Changed _Queue.enqueue()_ method so to return 1 if item has been enqueued or 0 otherwise
- Changed accessories update logic to avoid enqueuing additional update requests if one is already in the queue (currently only on Valve accessory)
- Fixed typo in _modbus-logo.ts_
- Added new debug log message to expose the amount of items in the queue
- Updated dependencies, readme and changelog

**Known Issues:**
- Using the _Queue.bequeue()_ method (as with pushButtons or accessories set methods) might make the Queue to grow larger than maximum allowed capacity, however this shouldn't create any major issue as the size of the update queue is limited
- Erratic behavior might occur if queue size is smaller than the total number of update calls of the accessories, as some of them won't fit in the queue
