### PR TITLE
Integrated valve as sub-accessory of IrrigationSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Name                     | Value               | Required | Option for | Notes
 `irrigationSystemSetActiveOff`   | "V4.2"    | yes*     | "irrigationSystem" | Irrigation System Set Active to Off - Mn or Vn.n
 `irrigationSystemGetProgramMode` | "VW54"     | yes*     | "irrigationSystem" | Irrigation System Get Program Mode - AMn or VWn - (0 - No Program scheduled; 1 - Program scheduled; 2 - Program scheduled manual Mode)
 `irrigationSystemGetInUse`       | "V4.3"    | yes*     | "irrigationSystem" | Irrigation System Get In Use - Mn or Vn.n
+`irrigationSystemAutoUpdate`     | 1         | no*      | "irrigationSystem" | Auto update of Irrigation System based on valves sub-accessories. If set, makes `irrigationSystemGetActive` and `irrigationSystemGetInUse` no longer needed
 
 ```json
 {
@@ -287,6 +288,15 @@ Name                     | Value               | Required | Option for | Notes
     "irrigationSystemSetActiveOff": "V4.2",
     "irrigationSystemGetProgramMode": "VW54",
     "irrigationSystemGetInUse": "V4.3"
+}
+
+{
+    "name": "Item-10",
+    "type": "irrigationSystem",
+    "irrigationSystemSetActiveOn": "V4.1",
+    "irrigationSystemSetActiveOff": "V4.2",
+    "irrigationSystemGetProgramMode": "VW54",
+    "irrigationSystemAutoUpdate": 1
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ Name                            | Value     | Required | Option for | Notes
 `valveGetDuration`              | "VW56"    | no*      | "valve" | Valve Get Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
 `valveGetRemainingDuration`     | "VW58"    | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
 `valveGetRemainingDuration`     | "VW58"    | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveSetIsConfigured`          | "V5.4"    | no*      | "valve" | Valve Set Is Configured / Enabled - Mn or Vn.n
+`valveGetIsConfigured`          | "V5.5"    | no*      | "valve" | Valve Get Is Configured / Enabled - Mn or Vn.n
 `valveParentIrrigationSystem`   | "Item-10" | no*      | "valve" | Valve parent Irrigation System accessory name, needed to create the valve as a sub-accessory of an Irrigation System
 `valveZone`                     | 1         | no*      | "valve" | Valve zone, needed when valve is part of an Irrigation System accessory
 

--- a/README.md
+++ b/README.md
@@ -292,16 +292,19 @@ Name                     | Value               | Required | Option for | Notes
 
 ## Valve Configuration ##
 
-Name                        | Value       | Required | Option for | Notes
---------------------------- | ----------- | -------- | ---------- | ------------------------
-`valveGetActive`            | "V5.0"      | yes*     | "valve" | Valve Get Active - Mn or Vn.n
-`valveSetActiveOn`          | "V5.1"      | yes*     | "valve" | Valve Set Active to On - Mn or Vn.n
-`valveSetActiveOff`         | "V5.2"      | yes*     | "valve" | Valve Set Active to Off - Mn or Vn.n
-`valveGetInUse`             | "V5.3"      | yes*     | "valve" | Valve Get In Use - Mn or Vn.n
-`valveType`                 | 0           | yes*     | "valve" | Valve Type - Generic Valve = 0, Irrigation = 1, Shower Head = 2, Water Faucet = 3,
-`valveSetDuration`          | "VW56"      | no*      | "valve" | Valve Set Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
-`valveGetDuration`          | "VW56"      | no*      | "valve" | Valve Get Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
-`valveGetRemainingDuration` | "VW58"      | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+Name                            | Value     | Required | Option for | Notes
+------------------------------- | --------- | -------- | ---------- | ------------------------
+`valveGetActive`                | "V5.0"    | yes*     | "valve" | Valve Get Active - Mn or Vn.n
+`valveSetActiveOn`              | "V5.1"    | yes*     | "valve" | Valve Set Active to On - Mn or Vn.n
+`valveSetActiveOff`             | "V5.2"    | yes*     | "valve" | Valve Set Active to Off - Mn or Vn.n
+`valveGetInUse`                 | "V5.3"    | yes*     | "valve" | Valve Get In Use - Mn or Vn.n
+`valveType`                     | 0         | yes*     | "valve" | Valve Type - Generic Valve = 0, Irrigation = 1, Shower Head = 2, Water Faucet = 3. Defaults to 1 when `valveParentIrrigationSystem` is set 
+`valveSetDuration`              | "VW56"    | no*      | "valve" | Valve Set Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveGetDuration`              | "VW56"    | no*      | "valve" | Valve Get Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveGetRemainingDuration`     | "VW58"    | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveGetRemainingDuration`     | "VW58"    | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveParentIrrigationSystem`   | "Item-10" | no*      | "valve" | Valve parent Irrigation System accessory name, needed to create the valve as a sub-accessory of an Irrigation System
+`valveZone`                     | 1         | no*      | "valve" | Valve zone, needed when valve is part of an Irrigation System accessory
 
 ```json
 {
@@ -314,7 +317,9 @@ Name                        | Value       | Required | Option for | Notes
     "valveType": 1,
     "valveSetDuration": "VW56",
     "valveGetDuration": "VW56",
-    "valveGetRemainingDuration": "VW58"
+    "valveGetRemainingDuration": "VW58",
+    "valveParentIrrigationSystem": "Item-10",
+    "valveZone": 1
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Name                     | Value               | Required | Option for | Notes
 `irrigationSystemSetActiveOff`   | "V4.2"    | yes*     | "irrigationSystem" | Irrigation System Set Active to Off - Mn or Vn.n
 `irrigationSystemGetProgramMode` | "VW54"     | yes*     | "irrigationSystem" | Irrigation System Get Program Mode - AMn or VWn - (0 - No Program scheduled; 1 - Program scheduled; 2 - Program scheduled manual Mode)
 `irrigationSystemGetInUse`       | "V4.3"    | yes*     | "irrigationSystem" | Irrigation System Get In Use - Mn or Vn.n
+`irrigationSystemGetWaterLevel`  | "VW55"    | no*      | "irrigationSystem" | Irrigation System Get Water Level % - AMn or VWn
 `irrigationSystemAutoUpdate`     | 1         | no*      | "irrigationSystem" | Auto update of Irrigation System based on valves sub-accessories. If set, makes `irrigationSystemGetActive` and `irrigationSystemGetInUse` no longer needed
 
 ```json
@@ -287,7 +288,8 @@ Name                     | Value               | Required | Option for | Notes
     "irrigationSystemSetActiveOn": "V4.1",
     "irrigationSystemSetActiveOff": "V4.2",
     "irrigationSystemGetProgramMode": "VW54",
-    "irrigationSystemGetInUse": "V4.3"
+    "irrigationSystemGetInUse": "V4.3",
+    "irrigationSystemGetWaterLevel": "VW55"
 }
 
 {
@@ -296,6 +298,7 @@ Name                     | Value               | Required | Option for | Notes
     "irrigationSystemSetActiveOn": "V4.1",
     "irrigationSystemSetActiveOff": "V4.2",
     "irrigationSystemGetProgramMode": "VW54",
+    "irrigationSystemGetWaterLevel": "VW55",
     "irrigationSystemAutoUpdate": 1
 }
 ```

--- a/config.schema.json
+++ b/config.schema.json
@@ -486,6 +486,22 @@
                 "functionBody": "return model.devices.type == 'valve';"
             }
           },
+          "valveParentIrrigationSystem": {
+            "title": "Valve parent Irrigation System accessory (Not Required)",
+            "type": "string",
+            "placeholder": "IrrigationSystem1",
+            "condition": {
+                "functionBody": "return model.devices.type == 'valve';"
+            }
+          },
+          "valveZone": {
+            "title": "Valve zone, needed when valve is part of an Irrigation System accessory (Not Required)",
+            "type": "string",
+            "placeholder": "IrrigationSystem1",
+            "condition": {
+                "functionBody": "return model.devices.type == 'valve';"
+            }
+          },
 
           "fanGet": {
             "title": "Fan Get (Required)",

--- a/config.schema.json
+++ b/config.schema.json
@@ -421,6 +421,14 @@
                 "functionBody": "return model.devices.type == 'irrigationSystem';"
             }
           },
+          "irrigationSystemAutoUpdate": {
+            "title": "Irrigation System Auto Update (Not Required)",
+            "type": "string",
+            "placeholder": "1",
+            "condition": {
+                "functionBody": "return model.devices.type == 'irrigationSystem';"
+            }
+          },
 
           "valveGetActive": {
             "title": "Valve Get Active (Required)",

--- a/config.schema.json
+++ b/config.schema.json
@@ -421,6 +421,14 @@
                 "functionBody": "return model.devices.type == 'irrigationSystem';"
             }
           },
+          "irrigationSystemGetWaterLevel": {
+            "title": "Irrigation System Get WaterLevel (Not Required)",
+            "type": "string",
+            "placeholder": "VW55",
+            "condition": {
+                "functionBody": "return model.devices.type == 'irrigationSystem';"
+            }
+          },
           "irrigationSystemAutoUpdate": {
             "title": "Irrigation System Auto Update (Not Required)",
             "type": "string",

--- a/config.schema.json
+++ b/config.schema.json
@@ -502,6 +502,22 @@
                 "functionBody": "return model.devices.type == 'valve';"
             }
           },
+          "valveSetIsConfigured": {
+            "title": "Valve Set Is Configured - Enabled (Not Required)",
+            "type": "string",
+            "placeholder": "V5.4",
+            "condition": {
+                "functionBody": "return model.devices.type == 'valve';"
+            }
+          },
+          "valveGetIsConfigured": {
+            "title": "Valve Get Is Configured - Enabled (Not Required)",
+            "type": "string",
+            "placeholder": "V5.5",
+            "condition": {
+                "functionBody": "return model.devices.type == 'valve';"
+            }
+          },
           "valveParentIrrigationSystem": {
             "title": "Valve parent Irrigation System accessory (Not Required)",
             "type": "string",

--- a/src/accessories/valvePlatformAccessory.ts
+++ b/src/accessories/valvePlatformAccessory.ts
@@ -102,7 +102,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
   }
 
   errorCheck() {
-    if (!this.device.valveGetActive || !this.device.valveSetActiveOn || !this.device.valveSetActiveOff || !this.device.valveGetInUse || !this.device.valveType) {
+    if (!this.device.valveGetActive || !this.device.valveSetActiveOn || !this.device.valveSetActiveOff || !this.device.valveGetInUse) {
       this.platform.log.error('[%s] LOGO! Addresses not correct!', this.device.name);
     }
     if (this.device.valveParentIrrigationSystem && !this.device.valveZone) {

--- a/src/accessories/valvePlatformAccessory.ts
+++ b/src/accessories/valvePlatformAccessory.ts
@@ -76,7 +76,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
 
     if (this.device.valveSetIsConfigured && this.device.valveGetIsConfigured) {
       this.service.getCharacteristic(this.platform.Characteristic.IsConfigured)
-        .onSet(this.setIsConfigured.bind(this))
+        //.onSet(this.setIsConfigured.bind(this))
         .onGet(this.getIsConfigured.bind(this));
     }
     

--- a/src/accessories/valvePlatformAccessory.ts
+++ b/src/accessories/valvePlatformAccessory.ts
@@ -30,7 +30,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
 
   name: string;
 
-  constructor( api: API, platform: any, device: any ) {
+  constructor( api: API, platform: any, device: any, irrigationSystem?: any ) {
 
     this.name       = device.name;
     this.api        = api;
@@ -42,8 +42,15 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
 
     this.accStates.ValveType = this.device.valveType;
 
-    this.service = new this.api.hap.Service.Valve(this.device.name);
-
+    if (irrigationSystem) {
+      this.service = new this.api.hap.Service.Valve(this.device.name, this.device.valveZone);
+      this.service.setCharacteristic(this.platform.Characteristic.ServiceLabelIndex, this.device.valveZone);
+      this.accStates.ValveType = 1;
+    }
+    else {
+      this.service = new this.api.hap.Service.Valve(this.device.name);
+    }
+  
     this.service.getCharacteristic(this.platform.Characteristic.Active)
       .onSet(this.setActive.bind(this))
       .onGet(this.getActive.bind(this));
@@ -71,6 +78,11 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
 
+    if (irrigationSystem){
+      irrigationSystem.service.addLinkedService(this.service);
+      irrigationSystem.servicesArray.push(this.service);
+    }
+
     this.updateActiveQueued = false;
     this.updateInUseQueued = false;
     this.updateRemainingDurationQueued = false;
@@ -93,6 +105,10 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
     if (!this.device.valveGetActive || !this.device.valveSetActiveOn || !this.device.valveSetActiveOff || !this.device.valveGetInUse || !this.device.valveType) {
       this.platform.log.error('[%s] LOGO! Addresses not correct!', this.device.name);
     }
+    if (this.device.valveParentIrrigationSystem && !this.device.valveZone) {
+      this.platform.log.error('[%s] zone parameter must be set to be included in an IrrigationSystem', this.device.name);
+    }
+
   }
 
   getServices(): Service[] {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -137,7 +137,7 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
 
           case "irrigationSystem":
             this.accessoriesArray.push( new IrrigationSystemPlatformAccessory(this.api, this, device) );
-            this.queueMinSize += 3;
+            this.queueMinSize += 4;
             break;
 
           case "valve":

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -141,10 +141,10 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
             break;
 
           case "valve":
-            this.queueMinSize += 4;
             if (!(device.valveParentIrrigationSystem)){
               this.accessoriesArray.push( new ValvePlatformAccessory(this.api, this, device) );
             }
+            this.queueMinSize += 4;
             break;
 
           case "fan":

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -141,8 +141,10 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
             break;
 
           case "valve":
-            this.accessoriesArray.push( new ValvePlatformAccessory(this.api, this, device) );
             this.queueMinSize += 4;
+            if (!(device.valveParentIrrigationSystem)){
+              this.accessoriesArray.push( new ValvePlatformAccessory(this.api, this, device) );
+            }
             break;
 
           case "fan":

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -144,7 +144,7 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
             if (!(device.valveParentIrrigationSystem)){
               this.accessoriesArray.push( new ValvePlatformAccessory(this.api, this, device) );
             }
-            this.queueMinSize += 4;
+            this.queueMinSize += 5;
             break;
 
           case "fan":


### PR DESCRIPTION
**Changes:**
- Added possibility of creating a valve as a sub-accessory of an IrrigationSystem by configuring its `valveZone` and `valveParentIrrigationSystem` options
- Added possibility of having the IrrigationSystem to auto-update its `active` and `InUse` properties by automatically checking its children accessories (setting its `irrigationSystemAutoUpdate` property to 1)


**Bugfix:**
- Removed `valveType` from `valve.errorCheck()` as `valveType = 0` is allowed and corresponds to a _generic valve_ according to Apple HAP

