### PR TITLE
Integration of water valves into irrigation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,13 +273,14 @@ Name                     | Value              | Required | Option for | Notes
 
 Name                     | Value               | Required | Option for | Notes
 ------------------------ | ------------------- | -------- | ---------- | ------------------------
-`irrigationSystemGetActive`      | "V4.0"    | yes*     | "irrigationSystem" | Irrigation System Get Active - Mn or Vn.n
-`irrigationSystemSetActiveOn`    | "V4.1"    | yes*     | "irrigationSystem" | Irrigation System Set Active to On - Mn or Vn.n
-`irrigationSystemSetActiveOff`   | "V4.2"    | yes*     | "irrigationSystem" | Irrigation System Set Active to Off - Mn or Vn.n
-`irrigationSystemGetProgramMode` | "VW54"     | yes*     | "irrigationSystem" | Irrigation System Get Program Mode - AMn or VWn - (0 - No Program scheduled; 1 - Program scheduled; 2 - Program scheduled manual Mode)
-`irrigationSystemGetInUse`       | "V4.3"    | yes*     | "irrigationSystem" | Irrigation System Get In Use - Mn or Vn.n
-`irrigationSystemGetWaterLevel`  | "VW56"    | no*      | "irrigationSystem" | Irrigation System Get Water Level % - AMn or VWn
-`irrigationSystemAutoUpdate`     | 1         | no*      | "irrigationSystem" | Auto update of Irrigation System based on valves sub-accessories. If set, makes `irrigationSystemGetActive` and `irrigationSystemGetInUse` no longer needed
+`irrigationSystemGetActive`             | "V4.0"    | yes*     | "irrigationSystem" | Irrigation System Get Active - Mn or Vn.n
+`irrigationSystemSetActiveOn`           | "V4.1"    | yes*     | "irrigationSystem" | Irrigation System Set Active to On - Mn or Vn.n
+`irrigationSystemSetActiveOff`          | "V4.2"    | yes*     | "irrigationSystem" | Irrigation System Set Active to Off - Mn or Vn.n
+`irrigationSystemGetProgramMode`        | "VW54"     | yes*    | "irrigationSystem" | Irrigation System Get Program Mode - AMn or VWn - (0 - No Program scheduled; 1 - Program scheduled; 2 - Program scheduled manual Mode)
+`irrigationSystemGetInUse`              | "V4.3"    | yes*     | "irrigationSystem" | Irrigation System Get In Use - Mn or Vn.n
+`irrigationSystemGetRemainingDuration`  | "VW56"    | no*      | "irrigationSystem" | Irrigation System Get Remaining Duration - AMn or VWn
+`irrigationSystemGetWaterLevel`         | "VW58"    | no*      | "irrigationSystem" | Irrigation System Get Water Level % - AMn or VWn
+`irrigationSystemAutoUpdate`            | 1         | no*      | "irrigationSystem" | Auto update of Irrigation System based on valves sub-accessories. If set `irrigationSystemGetActive` and `irrigationSystemGetInUse` are not necessary and can remain unset
 
 ```json
 {
@@ -290,7 +291,8 @@ Name                     | Value               | Required | Option for | Notes
     "irrigationSystemSetActiveOff": "V4.2",
     "irrigationSystemGetProgramMode": "VW54",
     "irrigationSystemGetInUse": "V4.3",
-    "irrigationSystemGetWaterLevel": "VW56"
+    "irrigationSystemGetRemainingDuration": "VW56",
+    "irrigationSystemGetWaterLevel": "VW58"
 }
 
 {
@@ -299,7 +301,8 @@ Name                     | Value               | Required | Option for | Notes
     "irrigationSystemSetActiveOn": "V4.1",
     "irrigationSystemSetActiveOff": "V4.2",
     "irrigationSystemGetProgramMode": "VW54",
-    "irrigationSystemGetWaterLevel": "VW56",
+    "irrigationSystemGetRemainingDuration": "VW56",
+    "irrigationSystemGetWaterLevel": "VW58",
     "irrigationSystemAutoUpdate": 1
 }
 ```

--- a/README.md
+++ b/README.md
@@ -293,16 +293,19 @@ Name                     | Value               | Required | Option for | Notes
 
 ## Valve Configuration ##
 
-Name                        | Value       | Required | Option for | Notes
---------------------------- | ----------- | -------- | ---------- | ------------------------
-`valveGetActive`            | "V5.0"      | yes*     | "valve" | Valve Get Active - Mn or Vn.n
-`valveSetActiveOn`          | "V5.1"      | yes*     | "valve" | Valve Set Active to On - Mn or Vn.n
-`valveSetActiveOff`         | "V5.2"      | yes*     | "valve" | Valve Set Active to Off - Mn or Vn.n
-`valveGetInUse`             | "V5.3"      | yes*     | "valve" | Valve Get In Use - Mn or Vn.n
-`valveType`                 | 0           | yes*     | "valve" | Valve Type - Generic Valve = 0, Irrigation = 1, Shower Head = 2, Water Faucet = 3,
-`valveSetDuration`          | "VW56"      | no*      | "valve" | Valve Set Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
-`valveGetDuration`          | "VW56"      | no*      | "valve" | Valve Get Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
-`valveGetRemainingDuration` | "VW58"      | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+Name                            | Value     | Required | Option for | Notes
+------------------------------- | --------- | -------- | ---------- | ------------------------
+`valveGetActive`                | "V5.0"    | yes*     | "valve" | Valve Get Active - Mn or Vn.n
+`valveSetActiveOn`              | "V5.1"    | yes*     | "valve" | Valve Set Active to On - Mn or Vn.n
+`valveSetActiveOff`             | "V5.2"    | yes*     | "valve" | Valve Set Active to Off - Mn or Vn.n
+`valveGetInUse`                 | "V5.3"    | yes*     | "valve" | Valve Get In Use - Mn or Vn.n
+`valveType`                     | 0         | yes*     | "valve" | Valve Type - Generic Valve = 0, Irrigation = 1, Shower Head = 2, Water Faucet = 3. Defaults to 1 when `valveParentIrrigationSystem` is set 
+`valveSetDuration`              | "VW56"    | no*      | "valve" | Valve Set Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveGetDuration`              | "VW56"    | no*      | "valve" | Valve Get Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveGetRemainingDuration`     | "VW58"    | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveGetRemainingDuration`     | "VW58"    | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveParentIrrigationSystem`   | "Item-10" | no*      | "valve" | Valve parent Irrigation System accessory name, needed to create the valve as a sub-accessory of an Irrigation System
+`valveZone`                     | 1         | no*      | "valve" | Valve zone, needed when valve is part of an Irrigation System accessory
 
 ```json
 {
@@ -315,7 +318,9 @@ Name                        | Value       | Required | Option for | Notes
     "valveType": 1,
     "valveSetDuration": "VW56",
     "valveGetDuration": "VW56",
-    "valveGetRemainingDuration": "VW58"
+    "valveGetRemainingDuration": "VW58",
+    "valveParentIrrigationSystem": "Item-10",
+    "valveZone": 1
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Name                     | Value               | Required | Option for | Notes
 `irrigationSystemSetActiveOff`   | "V4.2"    | yes*     | "irrigationSystem" | Irrigation System Set Active to Off - Mn or Vn.n
 `irrigationSystemGetProgramMode` | "VW54"     | yes*     | "irrigationSystem" | Irrigation System Get Program Mode - AMn or VWn - (0 - No Program scheduled; 1 - Program scheduled; 2 - Program scheduled manual Mode)
 `irrigationSystemGetInUse`       | "V4.3"    | yes*     | "irrigationSystem" | Irrigation System Get In Use - Mn or Vn.n
+`irrigationSystemAutoUpdate`     | 1         | no*      | "irrigationSystem" | Auto update of Irrigation System based on valves sub-accessories. If set, makes `irrigationSystemGetActive` and `irrigationSystemGetInUse` no longer needed
 
 ```json
 {
@@ -288,6 +289,15 @@ Name                     | Value               | Required | Option for | Notes
     "irrigationSystemSetActiveOff": "V4.2",
     "irrigationSystemGetProgramMode": "VW54",
     "irrigationSystemGetInUse": "V4.3"
+}
+
+{
+    "name": "Item-10",
+    "type": "irrigationSystem",
+    "irrigationSystemSetActiveOn": "V4.1",
+    "irrigationSystemSetActiveOff": "V4.2",
+    "irrigationSystemGetProgramMode": "VW54",
+    "irrigationSystemAutoUpdate": 1
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Name                     | Value               | Required | Option for | Notes
 `irrigationSystemSetActiveOff`   | "V4.2"    | yes*     | "irrigationSystem" | Irrigation System Set Active to Off - Mn or Vn.n
 `irrigationSystemGetProgramMode` | "VW54"     | yes*     | "irrigationSystem" | Irrigation System Get Program Mode - AMn or VWn - (0 - No Program scheduled; 1 - Program scheduled; 2 - Program scheduled manual Mode)
 `irrigationSystemGetInUse`       | "V4.3"    | yes*     | "irrigationSystem" | Irrigation System Get In Use - Mn or Vn.n
+`irrigationSystemGetWaterLevel`  | "VW56"    | no*      | "irrigationSystem" | Irrigation System Get Water Level % - AMn or VWn
 `irrigationSystemAutoUpdate`     | 1         | no*      | "irrigationSystem" | Auto update of Irrigation System based on valves sub-accessories. If set, makes `irrigationSystemGetActive` and `irrigationSystemGetInUse` no longer needed
 
 ```json
@@ -288,7 +289,8 @@ Name                     | Value               | Required | Option for | Notes
     "irrigationSystemSetActiveOn": "V4.1",
     "irrigationSystemSetActiveOff": "V4.2",
     "irrigationSystemGetProgramMode": "VW54",
-    "irrigationSystemGetInUse": "V4.3"
+    "irrigationSystemGetInUse": "V4.3",
+    "irrigationSystemGetWaterLevel": "VW56"
 }
 
 {
@@ -297,6 +299,7 @@ Name                     | Value               | Required | Option for | Notes
     "irrigationSystemSetActiveOn": "V4.1",
     "irrigationSystemSetActiveOff": "V4.2",
     "irrigationSystemGetProgramMode": "VW54",
+    "irrigationSystemGetWaterLevel": "VW56",
     "irrigationSystemAutoUpdate": 1
 }
 ```

--- a/README.md
+++ b/README.md
@@ -317,6 +317,9 @@ Name                            | Value     | Required | Option for | Notes
 `valveGetDuration`              | "VW56"    | no*      | "valve" | Valve Get Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
 `valveGetRemainingDuration`     | "VW58"    | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
 `valveGetRemainingDuration`     | "VW58"    | no*      | "valve" | Valve Get Remaining Duration - AMn or VWn - Value in Seconds (0 - 3600 sec)
+`valveSetIsConfiguredOn`        | "V5.4"    | no*      | "valve" | Valve Set Is Configured / Enabled On - Mn or Vn.n
+`valveSetIsConfiguredOff`       | "V5.5"    | no*      | "valve" | Valve Set Is Configured / Enabled Off - Mn or Vn.n
+`valveGetIsConfigured`          | "V5.6"    | no*      | "valve" | Valve Get Is Configured / Enabled - Mn or Vn.n
 `valveParentIrrigationSystem`   | "Item-10" | no*      | "valve" | Valve parent Irrigation System accessory name, needed to create the valve as a sub-accessory of an Irrigation System
 `valveZone`                     | 1         | no*      | "valve" | Valve zone, needed when valve is part of an Irrigation System accessory
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -486,6 +486,22 @@
                 "functionBody": "return model.devices.type == 'valve';"
             }
           },
+          "valveParentIrrigationSystem": {
+            "title": "Valve parent Irrigation System accessory (Not Required)",
+            "type": "string",
+            "placeholder": "IrrigationSystem1",
+            "condition": {
+                "functionBody": "return model.devices.type == 'valve';"
+            }
+          },
+          "valveZone": {
+            "title": "Valve zone, needed when valve is part of an Irrigation System accessory (Not Required)",
+            "type": "string",
+            "placeholder": "IrrigationSystem1",
+            "condition": {
+                "functionBody": "return model.devices.type == 'valve';"
+            }
+          },
 
           "fanGet": {
             "title": "Fan Get (Required)",

--- a/config.schema.json
+++ b/config.schema.json
@@ -421,6 +421,14 @@
                 "functionBody": "return model.devices.type == 'irrigationSystem';"
             }
           },
+          "irrigationSystemAutoUpdate": {
+            "title": "Irrigation System Auto Update (Not Required)",
+            "type": "string",
+            "placeholder": "1",
+            "condition": {
+                "functionBody": "return model.devices.type == 'irrigationSystem';"
+            }
+          },
 
           "valveGetActive": {
             "title": "Valve Get Active (Required)",

--- a/config.schema.json
+++ b/config.schema.json
@@ -421,6 +421,14 @@
                 "functionBody": "return model.devices.type == 'irrigationSystem';"
             }
           },
+          "irrigationSystemGetWaterLevel": {
+            "title": "Irrigation System Get WaterLevel (Not Required)",
+            "type": "string",
+            "placeholder": "VW55",
+            "condition": {
+                "functionBody": "return model.devices.type == 'irrigationSystem';"
+            }
+          },
           "irrigationSystemAutoUpdate": {
             "title": "Irrigation System Auto Update (Not Required)",
             "type": "string",

--- a/config.schema.json
+++ b/config.schema.json
@@ -502,6 +502,30 @@
                 "functionBody": "return model.devices.type == 'valve';"
             }
           },
+          "valveSetIsConfiguredOn": {
+            "title": "Valve Set Is Configured On - Enabled (Not Required)",
+            "type": "string",
+            "placeholder": "V5.4",
+            "condition": {
+                "functionBody": "return model.devices.type == 'valve';"
+            }
+          },
+          "valveSetIsConfiguredOff": {
+            "title": "Valve Set Is Configured Off - Enabled (Not Required)",
+            "type": "string",
+            "placeholder": "V5.4",
+            "condition": {
+                "functionBody": "return model.devices.type == 'valve';"
+            }
+          },
+          "valveGetIsConfigured": {
+            "title": "Valve Get Is Configured - Enabled (Not Required)",
+            "type": "string",
+            "placeholder": "V5.5",
+            "condition": {
+                "functionBody": "return model.devices.type == 'valve';"
+            }
+          },
           "valveParentIrrigationSystem": {
             "title": "Valve parent Irrigation System accessory (Not Required)",
             "type": "string",

--- a/config.schema.json
+++ b/config.schema.json
@@ -421,10 +421,18 @@
                 "functionBody": "return model.devices.type == 'irrigationSystem';"
             }
           },
+          "irrigationSystemGetRemainingDuration": {
+            "title": "Irrigation System Get RemainingDuration (Not Required)",
+            "type": "string",
+            "placeholder": "VW56",
+            "condition": {
+                "functionBody": "return model.devices.type == 'irrigationSystem';"
+            }
+          },
           "irrigationSystemGetWaterLevel": {
             "title": "Irrigation System Get WaterLevel (Not Required)",
             "type": "string",
-            "placeholder": "VW55",
+            "placeholder": "VW58",
             "condition": {
                 "functionBody": "return model.devices.type == 'irrigationSystem';"
             }

--- a/src/accessories/irrigationSystemPlatformAccessory.ts
+++ b/src/accessories/irrigationSystemPlatformAccessory.ts
@@ -129,7 +129,7 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
     if (value) {
       qItem = new QueueSendItem(this.device.irrigationSystemSetActiveOn, 1, this.pushButton);
     } else {
-      qItem = new QueueSendItem(this.device.irrigationSystemSetActiveOff, 1, this.pushButton);
+      qItem = new QueueSendItem(this.device.irrigationSystemSetActiveOff, this.pushButton, this.pushButton);
     }
     this.platform.queue.bequeue(qItem);
 

--- a/src/accessories/irrigationSystemPlatformAccessory.ts
+++ b/src/accessories/irrigationSystemPlatformAccessory.ts
@@ -11,10 +11,10 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
   private model: string = "IrrigationSystem";
 
   private api: API;
-  service: Service;
+  public service: Service;
   private information: Service;
   private valveAccessories: any[];
-  servicesArray: Service[];
+  public servicesArray: Service[];
   private valveZones: number[];
 
   private platform: any;

--- a/src/accessories/irrigationSystemPlatformAccessory.ts
+++ b/src/accessories/irrigationSystemPlatformAccessory.ts
@@ -14,7 +14,7 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
   public service: Service;
   private information: Service;
   private valveAccessories: any[];
-  public servicesArray: Service[];
+  public services: Service[];
   private valveZones: number[];
 
   private platform: any;
@@ -46,7 +46,7 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
     this.pushButton = (this.device.pushButton ? 1 : 0) || this.platform.pushButton;
     this.irrigationSystemAutoUpdate = (this.device.irrigationSystemAutoUpdate ? 1 : 0);
     this.valveAccessories = [];
-    this.servicesArray = [];
+    this.services = [];
     this.valveZones = [];
 
     this.errorCheck();
@@ -79,7 +79,7 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
       .setCharacteristic(this.api.hap.Characteristic.SerialNumber,     md5(this.device.name + this.model))
       .setCharacteristic(this.api.hap.Characteristic.FirmwareRevision, this.platform.firmwareRevision);
 
-    this.servicesArray.push(this.service, this.information);
+    this.services.push(this.service, this.information);
     
     const configDevices = this.platform.config.devices;
 
@@ -123,7 +123,7 @@ export class IrrigationSystemPlatformAccessory implements AccessoryPlugin {
   }
 
   getServices(): Service[] {
-    return this.servicesArray;
+    return this.services;
   }
 
   async setActive(value: CharacteristicValue) {

--- a/src/accessories/valvePlatformAccessory.ts
+++ b/src/accessories/valvePlatformAccessory.ts
@@ -102,7 +102,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
   }
 
   errorCheck() {
-    if (!this.device.valveGetActive || !this.device.valveSetActiveOn || !this.device.valveSetActiveOff || !this.device.valveGetInUse || !this.device.valveType) {
+    if (!this.device.valveGetActive || !this.device.valveSetActiveOn || !this.device.valveSetActiveOff || !this.device.valveGetInUse) {
       this.platform.log.error('[%s] LOGO! Addresses not correct!', this.device.name);
     }
     if (this.device.valveParentIrrigationSystem && !this.device.valveZone) {

--- a/src/accessories/valvePlatformAccessory.ts
+++ b/src/accessories/valvePlatformAccessory.ts
@@ -9,7 +9,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
   private model: string = "Valve";
 
   private api: API;
-  private service: Service;
+  public service: Service;
   private information: Service;
 
   private platform: any;

--- a/src/accessories/valvePlatformAccessory.ts
+++ b/src/accessories/valvePlatformAccessory.ts
@@ -1,4 +1,4 @@
-import { AccessoryPlugin, API, Service, CharacteristicValue } from 'homebridge';
+import { AccessoryPlugin, API, Service, CharacteristicValue, Perms } from 'homebridge';
 
 import { QueueSendItem, QueueReceiveItem } from "../queue";
 import { ErrorNumber } from "../error";
@@ -19,6 +19,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
   private updateInUseQueued: boolean;
   private updateRemainingDurationQueued: boolean;
   private updateSetDurationQueued: boolean;
+  private updateIsConfiguredQueued: boolean;
 
   private accStates = {
     Active: 0,
@@ -26,6 +27,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
     ValveType: 0,
     RemainingDuration: 0,
     SetDuration: 0,
+    IsConfigured: 0
   };
 
   name: string;
@@ -71,6 +73,13 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
         .onSet(this.setSetDuration.bind(this))
         .onGet(this.getSetDuration.bind(this));
     }
+
+    if (this.device.valveSetIsConfiguredOn && this.device.valveSetIsConfiguredOff && this.device.valveGetIsConfigured) {
+      this.service.getCharacteristic(this.platform.Characteristic.IsConfigured)
+        .setProps({perms: [Perms.NOTIFY, Perms.PAIRED_READ, Perms.PAIRED_WRITE]})  
+        .onSet(this.setIsConfigured.bind(this))
+        .onGet(this.getIsConfigured.bind(this));
+    }
     
     this.information = new this.api.hap.Service.AccessoryInformation()
       .setCharacteristic(this.api.hap.Characteristic.Manufacturer,     this.platform.manufacturer)
@@ -87,6 +96,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
     this.updateInUseQueued = false;
     this.updateRemainingDurationQueued = false;
     this.updateSetDurationQueued = false;
+    this.updateIsConfiguredQueued = false;
 
     if (this.platform.config.updateInterval) {
 
@@ -95,6 +105,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
         this.updateInUse();
         this.updateRemainingDuration();
         this.updateSetDuration();
+        this.updateIsConfigured();
       }, this.platform.config.updateInterval);
       
     }
@@ -127,7 +138,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
     if (value) {
       qItem = new QueueSendItem(this.device.valveSetActiveOn, 1, this.pushButton);
     } else {
-      qItem = new QueueSendItem(this.device.valveSetActiveOff, 1, this.pushButton);
+      qItem = new QueueSendItem(this.device.valveSetActiveOff, this.pushButton, this.pushButton);
     }
     this.platform.queue.bequeue(qItem);
 
@@ -147,6 +158,24 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
       this.platform.queue.bequeue(qItem);
       
     }
+
+  }
+
+  async setIsConfigured(value: CharacteristicValue) {
+    
+    this.accStates.IsConfigured = value as number;
+
+    if (this.platform.config.debugMsgLog || this.device.debugMsgLog) {
+      this.platform.log.info('[%s] Set Is Configured <- %i', this.device.name, value);
+    }
+
+    let qItem: QueueSendItem;
+    if (value) {
+      qItem = new QueueSendItem(this.device.valveSetIsConfiguredOn, 1, this.pushButton);
+    } else {
+      qItem = new QueueSendItem(this.device.valveSetIsConfiguredOff, this.pushButton, this.pushButton);
+    }
+    this.platform.queue.bequeue(qItem);
 
   }
 
@@ -187,6 +216,14 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
     this.updateSetDuration();
 
     return isSetDuration;
+  }
+
+  async getIsConfigured(): Promise<CharacteristicValue> {
+    
+    const IsConfigured = this.accStates.IsConfigured;
+    this.updateIsConfigured();
+
+    return IsConfigured;
   }
 
   updateActive() {
@@ -279,7 +316,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
 
   updateSetDuration() {
     
-    if (this.device.valveGetDuration) {
+    if (this.device.valveSetDuration && this.device.valveGetDuration) {
       
       if (this.updateSetDurationQueued) {return;}
       
@@ -302,6 +339,37 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
 
       if(this.platform.queue.enqueue(qItem) === 1) {
         this.updateSetDurationQueued = true;
+      }
+
+    }
+
+  }
+
+  updateIsConfigured() {
+    
+    if (this.device.valveSetIsConfiguredOn && this.device.valveSetIsConfiguredOff && this.device.valveGetIsConfigured) {
+      
+      if (this.updateIsConfiguredQueued) {return;}
+      
+      let qItem: QueueReceiveItem = new QueueReceiveItem(this.device.valveGetIsConfigured, async (value: number) => {
+
+        if (value != ErrorNumber.noData) {
+
+          this.accStates.IsConfigured = value as number;
+
+          if (this.platform.config.debugMsgLog || this.device.debugMsgLog) {
+            this.platform.log.info('[%s] Get IsConfigured -> %i', this.device.name, this.accStates.IsConfigured);
+          }
+
+          this.service.updateCharacteristic(this.api.hap.Characteristic.IsConfigured, this.accStates.IsConfigured);
+        }
+
+        this.updateIsConfiguredQueued = false;
+
+      });
+
+      if(this.platform.queue.enqueue(qItem) === 1) {
+        this.updateIsConfiguredQueued = true;
       }
 
     }

--- a/src/accessories/valvePlatformAccessory.ts
+++ b/src/accessories/valvePlatformAccessory.ts
@@ -70,6 +70,7 @@ export class ValvePlatformAccessory implements AccessoryPlugin {
     
     if (this.device.valveSetDuration && this.device.valveGetDuration) {
       this.service.getCharacteristic(this.platform.Characteristic.SetDuration)
+        .setProps({minValue: 0, maxValue: 14400})
         .onSet(this.setSetDuration.bind(this))
         .onGet(this.getSetDuration.bind(this));
     }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -142,10 +142,10 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
             break;
 
           case "valve":
-            this.queueMinSize += 4;
             if (!(device.valveParentIrrigationSystem)){
               this.accessoriesArray.push( new ValvePlatformAccessory(this.api, this, device) );
             }
+            this.queueMinSize += 4;
             break;
 
           case "fan":

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -145,7 +145,7 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
             if (!(device.valveParentIrrigationSystem)){
               this.accessoriesArray.push( new ValvePlatformAccessory(this.api, this, device) );
             }
-            this.queueMinSize += 4;
+            this.queueMinSize += 5;
             break;
 
           case "fan":

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -142,8 +142,10 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
             break;
 
           case "valve":
-            this.accessoriesArray.push( new ValvePlatformAccessory(this.api, this, device) );
             this.queueMinSize += 4;
+            if (!(device.valveParentIrrigationSystem)){
+              this.accessoriesArray.push( new ValvePlatformAccessory(this.api, this, device) );
+            }
             break;
 
           case "fan":

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -138,7 +138,7 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
 
           case "irrigationSystem":
             this.accessoriesArray.push( new IrrigationSystemPlatformAccessory(this.api, this, device) );
-            this.queueMinSize += 4;
+            this.queueMinSize += 5;
             break;
 
           case "valve":

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -138,7 +138,7 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
 
           case "irrigationSystem":
             this.accessoriesArray.push( new IrrigationSystemPlatformAccessory(this.api, this, device) );
-            this.queueMinSize += 3;
+            this.queueMinSize += 4;
             break;
 
           case "valve":


### PR DESCRIPTION
**Changes:**
- Added possibility to create a Valve as sub-services of an Irrigation System
- Added possibility of setting Irrigation System `autoUpdate` based on valve(s) status, reducing the amount of parameters to be read from LOGO!
- Removed `valveType` from `errorCheck()`, as `valveType = 0` is allowed
- Added `IsConfigured` characteristic (optional) to Valve accessory
- Added `RemainingDuration` characteristic (optional)  to Irrigation System accessory
- Changed `maxValue` for `SetDuration` to 4h for compatibility with Eve App


**Notes:**
- I changed `pushButton` behavior in both valve and Irrigation system accessories, so that when `pushButton` is set to 0, the plugin sends value 0 to LOGO!, so that when turned on, it writes 1 to Mn/Vn.n and when turned off, it writes 0 to Mn/Vn.n. This way you can use a single Mn/Vn.n for both on and off commands. As this differs from what is done on the other accessories, let me know if you want me to revert that or to change all the other ones
- I couldn't create a PR to `dev-1.3.6` as there seems to be some conflicts. I think it's because the previous PR I created was merged with that branch and now this creates conflicts. I'd suggest you do an interactive rebase of that branch, dropping all commits coming from the previous PR before attempting to merge this PR
- I'm creating a new valve UDF to easily support also the newly added HomeKit features. What I'm using at the moment is fairly more complex and not so easy to integrate. It'll be ready during the weekend
- From a style perspective, the Irrigation system is a bit different than the other accessories, as it is the only one so far to make use of a `services` array, but I'll probably add the same array to other accessories for another idea I'm working on at the moment (integrating [fakegato-history](https://github.com/simont77/fakegato-history) on some accessories to log values to Eve App)
- Changelog and `package.json` are not updated