### PR TITLE
fakegato-history Test

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   ],
   "dependencies": {
     "modbus-serial": "^8.0.5",
-    "node-snap7": "^1.0.6"
+    "node-snap7": "^1.0.6",
+    "fakegato-history": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.16.20",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -39,6 +39,7 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
   
   public readonly Service: typeof Service = this.api.hap.Service;
   public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
+  public FakeGatoHistoryService: any;
 
   public logo:  any;
 
@@ -94,6 +95,7 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
     this.firmwareRevision = pjson.version;
     this.pushButton       = (this.config.pushButton ? 1 : 0);
 
+    this.FakeGatoHistoryService = require('fakegato-history')(this.api);
     
     if (Array.isArray(this.config.devices)) {
 

--- a/src/platform_mb.ts
+++ b/src/platform_mb.ts
@@ -36,6 +36,7 @@ export class LogoHomebridgePlatform_MB implements StaticPlatformPlugin {
   
   public readonly Service: typeof Service = this.api.hap.Service;
   public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
+  public FakeGatoHistoryService: any;
 
   public logo:  any;
 
@@ -86,6 +87,8 @@ export class LogoHomebridgePlatform_MB implements StaticPlatformPlugin {
     this.model            = pjson.model;
     this.firmwareRevision = pjson.version;
     this.pushButton       = (this.config.pushButton ? 1 : 0);
+
+    this.FakeGatoHistoryService = require('fakegato-history')(this.api);
 
     if (this.config.interface == modbusInterface) {
 

--- a/src/platform_mb_s7.ts
+++ b/src/platform_mb_s7.ts
@@ -39,7 +39,8 @@ export class LogoHomebridgePlatform_MB_S7 implements StaticPlatformPlugin {
   
   public readonly Service: typeof Service = this.api.hap.Service;
   public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
-
+  public FakeGatoHistoryService: any;
+  
   public logo:  any;
 
   public ip: string;
@@ -94,6 +95,7 @@ export class LogoHomebridgePlatform_MB_S7 implements StaticPlatformPlugin {
     this.firmwareRevision = pjson.version;
     this.pushButton       = (this.config.pushButton ? 1 : 0);
 
+    this.FakeGatoHistoryService = require('fakegato-history')(this.api);
     
     if (Array.isArray(this.config.devices)) {
 


### PR DESCRIPTION
## Test of [fakegato-history](https://github.com/simont77/fakegato-history/) module integration to allow logging on Elgato Eve App ##

Let me know what you think

**Changes:**
- Added dependency
- Updated Temperature Sensor to allow logging:
    - made 'service' public
    - added 'services' array (required by _fakegato-history_)
    - added 'displayName' string (required by _fakegato-history_)
    - added logging function every 60s

**Bugfix:**
- Set _minValue_ property to temperature sensor to allow for negative values


**Notes:**
- Log is persistent and saved in a json file in homebridge folder, limited to 4032 samples (default), collected every 10m
- Only Temperature sensor is working at the moment
- to enable logging add '"enableLogging": 1' to the temperature sensor config
- Eve App only seems to be able to show a log for a defined set of characteristics, not any
- _Readme_ and _config.schema.json_ are not updated