### PR TITLE
Fix child bridge crash on ECONNRESET from LOGO! Modbus connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Logo Platform",
   "name": "homebridge-logo-platform",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "model": "Logo Platform",
   "description": "This is a Siemens LOGO! Platform Plugin.",
   "license": "---",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Logo Platform",
   "name": "homebridge-logo-platform",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "model": "Logo Platform",
   "description": "This is a Siemens LOGO! Platform Plugin.",
   "license": "---",
@@ -29,7 +29,8 @@
   "scripts": {
     "lint": "eslint src/**.ts --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
-    "build": "rimraf ./dist && tsc"
+    "build": "rimraf ./dist && tsc",
+    "prepare": "npm run build"
   },
   "keywords": [
     "homebridge-plugin",

--- a/src/modbus-logo.ts
+++ b/src/modbus-logo.ts
@@ -139,6 +139,11 @@ export class ModBusLogo {
         
         let len = 1;
         let client = new ModbusRTU();
+        (client as any).on('error', (err: Error) => {
+            if (debugLog == 1) {
+                log('ModBus socket error: ' + err.message);
+            }
+        });
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
@@ -172,6 +177,11 @@ export class ModBusLogo {
         
         let len = 1;
         let client = new ModbusRTU();
+        (client as any).on('error', (err: Error) => {
+            if (debugLog == 1) {
+                log('ModBus socket error: ' + err.message);
+            }
+        });
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
@@ -205,6 +215,11 @@ export class ModBusLogo {
         
         let len = 1;
         let client = new ModbusRTU();
+        (client as any).on('error', (err: Error) => {
+            if (debugLog == 1) {
+                log('ModBus socket error: ' + err.message);
+            }
+        });
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
@@ -242,6 +257,11 @@ export class ModBusLogo {
         
         let len = (addr.wLen == WordLen.MBWLDWord ? 2 : 1);
         let client = new ModbusRTU();
+        (client as any).on('error', (err: Error) => {
+            if (debugLog == 1) {
+                log('ModBus socket error: ' + err.message);
+            }
+        });
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
@@ -299,6 +319,11 @@ export class ModBusLogo {
         }
 
         let client = new ModbusRTU();
+        (client as any).on('error', (err: Error) => {
+            if (debugLog == 1) {
+                log('ModBus socket error: ' + err.message);
+            }
+        });
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
@@ -331,6 +356,11 @@ export class ModBusLogo {
         }
 
         let client = new ModbusRTU();
+        (client as any).on('error', (err: Error) => {
+            if (debugLog == 1) {
+                log('ModBus socket error: ' + err.message);
+            }
+        });
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
@@ -361,6 +391,11 @@ export class ModBusLogo {
         }
 
         let client = new ModbusRTU();
+        (client as any).on('error', (err: Error) => {
+            if (debugLog == 1) {
+                log('ModBus socket error: ' + err.message);
+            }
+        });
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {

--- a/src/modbus-logo.ts
+++ b/src/modbus-logo.ts
@@ -147,6 +147,17 @@ export class ModBusLogo {
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
+            const port = (client as any)._port;
+            if (port) {
+                port.on('error', (err: Error) => {
+                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+                });
+                if (port._client && typeof port._client.on === 'function') {
+                    port._client.on('error', (err: Error) => {
+                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
+                    });
+                }
+            }
             client.setTimeout(this.timeout);
             client.setID(1);
             client.readDiscreteInputs(addr.addr, len, (err: Error, data: ReadCoilResult) => {
@@ -185,6 +196,17 @@ export class ModBusLogo {
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
+            const port = (client as any)._port;
+            if (port) {
+                port.on('error', (err: Error) => {
+                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+                });
+                if (port._client && typeof port._client.on === 'function') {
+                    port._client.on('error', (err: Error) => {
+                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
+                    });
+                }
+            }
             client.setTimeout(this.timeout);
             client.setID(1);
             client.readCoils(addr.addr, len, (err: Error, data: ReadCoilResult) => {
@@ -223,6 +245,17 @@ export class ModBusLogo {
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
+            const port = (client as any)._port;
+            if (port) {
+                port.on('error', (err: Error) => {
+                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+                });
+                if (port._client && typeof port._client.on === 'function') {
+                    port._client.on('error', (err: Error) => {
+                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
+                    });
+                }
+            }
             client.setTimeout(this.timeout);
             client.setID(1);
             client.readInputRegisters(addr.addr, len, (err: Error, data: ReadRegisterResult) => {
@@ -265,6 +298,17 @@ export class ModBusLogo {
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
+            const port = (client as any)._port;
+            if (port) {
+                port.on('error', (err: Error) => {
+                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+                });
+                if (port._client && typeof port._client.on === 'function') {
+                    port._client.on('error', (err: Error) => {
+                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
+                    });
+                }
+            }
             client.setTimeout(this.timeout);
             client.setID(1);
             client.readHoldingRegisters(addr.addr, len, (err: Error, data: ReadRegisterResult) => {
@@ -327,6 +371,17 @@ export class ModBusLogo {
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
+            const port = (client as any)._port;
+            if (port) {
+                port.on('error', (err: Error) => {
+                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+                });
+                if (port._client && typeof port._client.on === 'function') {
+                    port._client.on('error', (err: Error) => {
+                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
+                    });
+                }
+            }
             client.setTimeout(this.timeout);
             client.setID(1);
 
@@ -364,6 +419,17 @@ export class ModBusLogo {
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
+            const port = (client as any)._port;
+            if (port) {
+                port.on('error', (err: Error) => {
+                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+                });
+                if (port._client && typeof port._client.on === 'function') {
+                    port._client.on('error', (err: Error) => {
+                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
+                    });
+                }
+            }
             client.setTimeout(this.timeout);
             client.setID(1);
 
@@ -399,6 +465,17 @@ export class ModBusLogo {
         retryCount = retryCount - 1;
 
         client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
+            const port = (client as any)._port;
+            if (port) {
+                port.on('error', (err: Error) => {
+                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+                });
+                if (port._client && typeof port._client.on === 'function') {
+                    port._client.on('error', (err: Error) => {
+                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
+                    });
+                }
+            }
             client.setTimeout(this.timeout);
             client.setID(1);
 

--- a/src/modbus-logo.ts
+++ b/src/modbus-logo.ts
@@ -127,6 +127,49 @@ export class ModBusLogo {
         }
     }
 
+    private withConnection(
+        client: any,
+        debugLog: number,
+        log: any,
+        onReady: () => void,
+        onConnectFail: () => void
+    ): void {
+        let failed = false;
+        const fail = (reason: string) => {
+            if (failed) return;
+            failed = true;
+            if (debugLog == 1) {
+                log('ModBus connect failed: ' + reason);
+            }
+            try { client.close(() => { /* ignore */ }); } catch (e) { /* ignore */ }
+            sleep(this.sleeptime).then(onConnectFail);
+        };
+        try {
+            client.connectTcpRTUBuffered(this.ip, { port: this.port }, (connectErr: any) => {
+                if (connectErr) {
+                    fail(connectErr.message || String(connectErr));
+                    return;
+                }
+                const port = client._port;
+                if (port) {
+                    port.on('error', (err: Error) => {
+                        if (debugLog == 1) log('ModBus port error: ' + err.message);
+                    });
+                    if (port._client && typeof port._client.on === 'function') {
+                        port._client.on('error', (err: Error) => {
+                            if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
+                        });
+                    }
+                }
+                client.setTimeout(this.timeout);
+                client.setID(1);
+                onReady();
+            });
+        } catch (e: any) {
+            fail('exception: ' + (e && e.message ? e.message : String(e)));
+        }
+    }
+
     readDiscreteInput(addr: LogoAddress, callBack: (value: number) => any, debugLog: number, log: any, retryCount: number) {
         
         if (retryCount == 0) {
@@ -146,34 +189,22 @@ export class ModBusLogo {
         });
         retryCount = retryCount - 1;
 
-        client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
-            const port = (client as any)._port;
-            if (port) {
-                port.on('error', (err: Error) => {
-                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+        this.withConnection(client, debugLog, log,
+            () => {
+                client.readDiscreteInputs(addr.addr, len, (err: Error, data: ReadCoilResult) => {
+                    if (err) {
+                        this.logError(log, err, debugLog, retryCount);
+                        sleep(this.sleeptime).then(() => {
+                            this.readDiscreteInput(addr, callBack, debugLog, log, retryCount);
+                        });
+                    } else {
+                        callBack((data.data[0] == true ? 1 : 0));
+                    }
+                    client.close();
                 });
-                if (port._client && typeof port._client.on === 'function') {
-                    port._client.on('error', (err: Error) => {
-                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
-                    });
-                }
-            }
-            client.setTimeout(this.timeout);
-            client.setID(1);
-            client.readDiscreteInputs(addr.addr, len, (err: Error, data: ReadCoilResult) => {
-                if (err) {
-                    this.logError(log, err, debugLog, retryCount);
-                    
-                    sleep(this.sleeptime).then(() => {
-                        this.readDiscreteInput(addr, callBack, debugLog, log, retryCount); 
-                    });
-
-                } else {
-                    callBack((data.data[0] == true ? 1 : 0));
-                }
-                client.close();
-            });
-        });
+            },
+            () => this.readDiscreteInput(addr, callBack, debugLog, log, retryCount)
+        );
     }
 
     readCoil(addr: LogoAddress, callBack: (value: number) => any, debugLog: number, log: any, retryCount: number) {
@@ -195,34 +226,22 @@ export class ModBusLogo {
         });
         retryCount = retryCount - 1;
 
-        client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
-            const port = (client as any)._port;
-            if (port) {
-                port.on('error', (err: Error) => {
-                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+        this.withConnection(client, debugLog, log,
+            () => {
+                client.readCoils(addr.addr, len, (err: Error, data: ReadCoilResult) => {
+                    if (err) {
+                        this.logError(log, err, debugLog, retryCount);
+                        sleep(this.sleeptime).then(() => {
+                            this.readCoil(addr, callBack, debugLog, log, retryCount);
+                        });
+                    } else {
+                        callBack((data.data[0] == true ? 1 : 0));
+                    }
+                    client.close();
                 });
-                if (port._client && typeof port._client.on === 'function') {
-                    port._client.on('error', (err: Error) => {
-                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
-                    });
-                }
-            }
-            client.setTimeout(this.timeout);
-            client.setID(1);
-            client.readCoils(addr.addr, len, (err: Error, data: ReadCoilResult) => {
-                if (err) {
-                    this.logError(log, err, debugLog, retryCount);
-                    
-                    sleep(this.sleeptime).then(() => {
-                        this.readCoil(addr, callBack, debugLog, log, retryCount); 
-                    });
-
-                } else {
-                    callBack((data.data[0] == true ? 1 : 0));
-                }
-                client.close();
-            });
-        });
+            },
+            () => this.readCoil(addr, callBack, debugLog, log, retryCount)
+        );
     }
 
     readInputRegister(addr: LogoAddress, callBack: (value: number) => any, debugLog: number, log: any, retryCount: number) {
@@ -244,38 +263,26 @@ export class ModBusLogo {
         });
         retryCount = retryCount - 1;
 
-        client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
-            const port = (client as any)._port;
-            if (port) {
-                port.on('error', (err: Error) => {
-                    if (debugLog == 1) log('ModBus port error: ' + err.message);
-                });
-                if (port._client && typeof port._client.on === 'function') {
-                    port._client.on('error', (err: Error) => {
-                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
-                    });
-                }
-            }
-            client.setTimeout(this.timeout);
-            client.setID(1);
-            client.readInputRegisters(addr.addr, len, (err: Error, data: ReadRegisterResult) => {
-                if (err) {
-                    this.logError(log, err, debugLog, retryCount);
-                    
-                    sleep(this.sleeptime).then(() => {
-                        this.readInputRegister(addr, callBack, debugLog, log, retryCount); 
-                    });
-
-                } else {
-                    let num = data.data[0];
-                    if (num > ErrorNumber.maxPositivNumber) {
-                        num = num - ErrorNumber.max16BitNumber;
+        this.withConnection(client, debugLog, log,
+            () => {
+                client.readInputRegisters(addr.addr, len, (err: Error, data: ReadRegisterResult) => {
+                    if (err) {
+                        this.logError(log, err, debugLog, retryCount);
+                        sleep(this.sleeptime).then(() => {
+                            this.readInputRegister(addr, callBack, debugLog, log, retryCount);
+                        });
+                    } else {
+                        let num = data.data[0];
+                        if (num > ErrorNumber.maxPositivNumber) {
+                            num = num - ErrorNumber.max16BitNumber;
+                        }
+                        callBack(num);
                     }
-                    callBack(num);
-                }
-                client.close();
-            });
-        });
+                    client.close();
+                });
+            },
+            () => this.readInputRegister(addr, callBack, debugLog, log, retryCount)
+        );
     }
 
     readHoldingRegister(addr: LogoAddress, callBack: (value: number) => any, debugLog: number, log: any, retryCount: number) {
@@ -297,60 +304,48 @@ export class ModBusLogo {
         });
         retryCount = retryCount - 1;
 
-        client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
-            const port = (client as any)._port;
-            if (port) {
-                port.on('error', (err: Error) => {
-                    if (debugLog == 1) log('ModBus port error: ' + err.message);
-                });
-                if (port._client && typeof port._client.on === 'function') {
-                    port._client.on('error', (err: Error) => {
-                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
-                    });
-                }
-            }
-            client.setTimeout(this.timeout);
-            client.setID(1);
-            client.readHoldingRegisters(addr.addr, len, (err: Error, data: ReadRegisterResult) => {
-                if (err) {
-                    this.logError(log, err, debugLog, retryCount);
-                    
-                    sleep(this.sleeptime).then(() => {
-                        this.readHoldingRegister(addr, callBack, debugLog, log, retryCount); 
-                    });
+        this.withConnection(client, debugLog, log,
+            () => {
+                client.readHoldingRegisters(addr.addr, len, (err: Error, data: ReadRegisterResult) => {
+                    if (err) {
+                        this.logError(log, err, debugLog, retryCount);
+                        sleep(this.sleeptime).then(() => {
+                            this.readHoldingRegister(addr, callBack, debugLog, log, retryCount);
+                        });
+                    } else {
+                        let num = 0;
+                        switch (addr.wLen) {
 
-                } else {
-                    let num = 0;
-                    switch (addr.wLen) {
+                            case WordLen.MBWLByte:
+                                num = (data.data[0] & 0b1111111100000000) >> 8;
+                                if (num > ErrorNumber.maxPositivNumber) {
+                                    num = num - ErrorNumber.max16BitNumber;
+                                }
+                                callBack(num);
+                                break;
 
-                        case WordLen.MBWLByte:
-                            num = (data.data[0] & 0b1111111100000000) >> 8;
-                            if (num > ErrorNumber.maxPositivNumber) {
-                                num = num - ErrorNumber.max16BitNumber;
-                            }
-                            callBack(num);
-                            break;
-    
-                        case WordLen.MBWLWord:
-                            num = data.data[0];
-                            if (num > ErrorNumber.maxPositivNumber) {
-                                num = num - ErrorNumber.max16BitNumber;
-                            }
-                            callBack(num);
-                            break;
-    
-                        case WordLen.MBWLDWord:
-                            num = (data.data[0] << 16) | data.data[1];
-                            if (num > ErrorNumber.maxPositivNumber) {
-                                num = num - ErrorNumber.max16BitNumber;
-                            }
-                            callBack(num);
-                            break;
+                            case WordLen.MBWLWord:
+                                num = data.data[0];
+                                if (num > ErrorNumber.maxPositivNumber) {
+                                    num = num - ErrorNumber.max16BitNumber;
+                                }
+                                callBack(num);
+                                break;
+
+                            case WordLen.MBWLDWord:
+                                num = (data.data[0] << 16) | data.data[1];
+                                if (num > ErrorNumber.maxPositivNumber) {
+                                    num = num - ErrorNumber.max16BitNumber;
+                                }
+                                callBack(num);
+                                break;
+                        }
                     }
-                }
-                client.close();
-            });
-        });
+                    client.close();
+                });
+            },
+            () => this.readHoldingRegister(addr, callBack, debugLog, log, retryCount)
+        );
     }
 
     writeCoil(addr: number, state: Boolean, debugLog: number, log: any, retryCount: number) {
@@ -370,34 +365,20 @@ export class ModBusLogo {
         });
         retryCount = retryCount - 1;
 
-        client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
-            const port = (client as any)._port;
-            if (port) {
-                port.on('error', (err: Error) => {
-                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+        this.withConnection(client, debugLog, log,
+            () => {
+                client.writeCoil(addr, state, (err: Error, data: WriteCoilResult) => {
+                    if (err) {
+                        this.logError(log, err, debugLog, retryCount);
+                        sleep(this.sleeptime).then(() => {
+                            this.writeCoil(addr, state, debugLog, log, retryCount);
+                        });
+                    }
+                    client.close();
                 });
-                if (port._client && typeof port._client.on === 'function') {
-                    port._client.on('error', (err: Error) => {
-                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
-                    });
-                }
-            }
-            client.setTimeout(this.timeout);
-            client.setID(1);
-
-            client.writeCoil(addr, state, (err: Error, data: WriteCoilResult) => {
-                if (err) {
-                    this.logError(log, err, debugLog, retryCount);
-
-                    sleep(this.sleeptime).then(() => {
-                        this.writeCoil(addr, state, debugLog, log, retryCount); 
-                    });
-
-                }
-                client.close(); 
-            });
-
-        });
+            },
+            () => this.writeCoil(addr, state, debugLog, log, retryCount)
+        );
 
     }
 
@@ -418,33 +399,20 @@ export class ModBusLogo {
         });
         retryCount = retryCount - 1;
 
-        client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
-            const port = (client as any)._port;
-            if (port) {
-                port.on('error', (err: Error) => {
-                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+        this.withConnection(client, debugLog, log,
+            () => {
+                client.writeRegister(addr, value, (err: Error, data: WriteRegisterResult) => {
+                    if (err) {
+                        this.logError(log, err, debugLog, retryCount);
+                        sleep(this.sleeptime).then(() => {
+                            this.writeRegister(addr, value, debugLog, log, retryCount);
+                        });
+                    }
+                    client.close();
                 });
-                if (port._client && typeof port._client.on === 'function') {
-                    port._client.on('error', (err: Error) => {
-                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
-                    });
-                }
-            }
-            client.setTimeout(this.timeout);
-            client.setID(1);
-
-            client.writeRegister(addr, value, (err: Error, data: WriteRegisterResult) => {
-                if (err) {
-                    this.logError(log, err, debugLog, retryCount);
-
-                    sleep(this.sleeptime).then(() => {
-                        this.writeRegister(addr, value, debugLog, log, retryCount); 
-                    });
-                }
-                
-                client.close();
-            });
-        });
+            },
+            () => this.writeRegister(addr, value, debugLog, log, retryCount)
+        );
     }
 
     writeRegisters(addr: number, value: number[], debugLog: number, log: any, retryCount: number) {
@@ -464,33 +432,20 @@ export class ModBusLogo {
         });
         retryCount = retryCount - 1;
 
-        client.connectTcpRTUBuffered(this.ip, { port: this.port }, () => {
-            const port = (client as any)._port;
-            if (port) {
-                port.on('error', (err: Error) => {
-                    if (debugLog == 1) log('ModBus port error: ' + err.message);
+        this.withConnection(client, debugLog, log,
+            () => {
+                client.writeRegisters(addr, value, (err: Error, data: WriteRegisterResult) => {
+                    if (err) {
+                        this.logError(log, err, debugLog, retryCount);
+                        sleep(this.sleeptime).then(() => {
+                            this.writeRegisters(addr, value, debugLog, log, retryCount);
+                        });
+                    }
+                    client.close();
                 });
-                if (port._client && typeof port._client.on === 'function') {
-                    port._client.on('error', (err: Error) => {
-                        if (debugLog == 1) log('ModBus raw socket error: ' + err.message);
-                    });
-                }
-            }
-            client.setTimeout(this.timeout);
-            client.setID(1);
-
-            client.writeRegisters(addr, value, (err: Error, data: WriteRegisterResult) => {
-                if (err) {
-                    this.logError(log, err, debugLog, retryCount);
-
-                    sleep(this.sleeptime).then(() => {
-                        this.writeRegisters(addr, value, debugLog, log, retryCount); 
-                    });
-                }
-                
-                client.close();
-            });
-        });
+            },
+            () => this.writeRegisters(addr, value, debugLog, log, retryCount)
+        );
     }
 
     logError(log: any, err: Error, debugLog: number, retryCount: number) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -47,6 +47,7 @@ import { LeakSensorPlatformAccessory }          from './sensors/leakSensorPlatfo
 import { WatchdogPlatformAccessory }            from './sensors/watchdogPlatformAccessory';
 
 const pjson = require('../package.json');
+declare const process: any;
 
 export class LogoHomebridgePlatform implements StaticPlatformPlugin {
   
@@ -87,6 +88,15 @@ export class LogoHomebridgePlatform implements StaticPlatformPlugin {
     public readonly api:    API,
   ) {
     // this.log.debug('Finished initializing platform:', this.config.name);
+
+    const transientNetErrors = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE', 'EHOSTUNREACH', 'ENETUNREACH'];
+    process.on('uncaughtException', (err: any) => {
+      if (err && err.code && transientNetErrors.indexOf(err.code) !== -1) {
+        this.log.warn('Suppressed transient network error: ' + err.code + ' - ' + err.message);
+        return;
+      }
+      throw err;
+    });
 
     this.ip            =           this.config.ip;
     this.interface     =           this.config.interface        || LogoInterface.Modbus;


### PR DESCRIPTION
## Summary

The child bridge crashes with `Error: read ECONNRESET` whenever the Siemens LOGO! 
abruptly resets the Modbus TCP connection (LOGO! has a very limited number of Modbus 
slots; the device closes connections under load, on reboot, on brief network glitches, 
etc.). The crash happens because the raw TCP socket created by `modbus-serial` has no 
`error` listener attached, so any socket error bubbles up as an uncaught exception and 
Node terminates the child bridge process. Homebridge then logs:

> [Bridge] Child bridge ended (code 1, signal null). The child bridge ended unexpectedly, 
> which is normally due to the plugin not catching its errors properly.

This PR adds defensive error handling at three levels so transient network errors no 
longer kill the bridge.

## Changes

### `src/modbus-logo.ts`

- After every `new ModbusRTU()`, attach `client.on('error', …)` so errors forwarded by 
  the modbus-serial transport layer are consumed.
- Inside each `connectTcpRTUBuffered()` callback, additionally attach error handlers to:
  - the internal `_port` (the `TcpRTUBufferedPort` instance), and
  - the underlying raw `net.Socket` (`_port._client`).
  
  This is the actual source of `ECONNRESET`; without a listener directly on the socket 
  the error escapes regardless of any handler on the `ModbusRTU` instance.

Applied to all seven I/O methods: `readDiscreteInput`, `readCoil`, `readInputRegister`, 
`readHoldingRegister`, `writeCoil`, `writeRegister`, `writeRegisters`.

When `debugMsgLog: 1` is set the suppressed errors are logged as 
`ModBus socket error: …` / `ModBus port error: …` / `ModBus raw socket error: …`.

### `src/platform.ts`

- Added a process-level `uncaughtException` safety net in the platform constructor that 
  filters for transient network error codes: `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, 
  `EPIPE`, `EHOSTUNREACH`, `ENETUNREACH`.
- Those are logged via `log.warn` and swallowed.
- Any other error is re-thrown so real bugs are still surfaced and not hidden by the 
  handler.
- `declare const process: any;` is used so the file compiles without requiring 
  `@types/node` to be present at build time.

### `package.json`

- Added `"prepare": "npm run build"` so the plugin can be installed directly from a Git 
  URL (`npm install -g github:user/repo` / `hb-service add user/repo`) and `dist/` is 
  built automatically.

## Why three layers

`modbus-serial` does not consistently re-emit raw socket errors on the `ModbusRTU` 
instance, and the connect callback may not always fire before the socket errors. The 
layered approach guarantees coverage:

1. `client.on('error')` — catches errors the library does forward.
2. Handler on `_port._client` — catches raw socket errors directly at their source.
3. `uncaughtException` filter — last-resort safety net for anything the first two miss, 
   strictly scoped to network errors.

## Tested

- Verified on Homebridge 2.0.x / Node 24 on Ubuntu with a LOGO! 8 over Modbus TCP.
- Before: `read ECONNRESET` → child bridge ends → restart cycle.
- After: `read ECONNRESET` → logged once → bridge stays up and continues polling on the 
  next interval.

## Backward compatibility

No public API changed. Existing configs work unchanged. Error suppression respects 
`debugMsgLog` for the per-call logs; the `uncaughtException` warning is always logged so 
operators stay aware of the underlying issue.